### PR TITLE
Support Python and ShellScript receipts

### DIFF
--- a/Embeddings/Python (for Just).sublime-syntax
+++ b/Embeddings/Python (for Just).sublime-syntax
@@ -1,0 +1,19 @@
+%YAML 1.2
+---
+name: Python (for Just)
+scope: source.python.embedded.just
+version: 2
+hidden: true
+
+extends: Packages/Python/Python.sublime-syntax
+
+contexts:
+  prototype:
+    - meta_prepend: true
+    - include: scope:source.just#recipe-content-interpolations
+    - include: scope:source.just#recipe-content-modifiers
+
+  string-prototype:
+    # Note: not yet supported by ST 4143/4146 (it's in preparation)
+    - meta_prepend: true
+    - include: scope:source.just#recipe-content-string-interpolations

--- a/Embeddings/ShellScript (for Just).sublime-syntax
+++ b/Embeddings/ShellScript (for Just).sublime-syntax
@@ -1,0 +1,25 @@
+%YAML 1.2
+---
+name: ShellScript (for Just)
+scope: source.shell.embedded.just
+version: 2
+hidden: true
+
+extends: Packages/ShellScript/Shell-Unix-Generic.sublime-syntax
+
+contexts:
+  prototype:
+    - meta_prepend: true
+    - include: scope:source.just#recipe-content-interpolations
+    - include: scope:source.just#recipe-content-modifiers
+
+  statements:
+    - meta_prepend: true
+    # command beginning with Just interpolation
+    - match: ^\s+(?=\{\{(?!\{))
+      push: [cmd-args, cmd-basic-name]
+
+  string-prototype:
+    # Note: not yet supported by ST 4143/4146 (it's in preparation)
+    - meta_prepend: true
+    - include: scope:source.just#recipe-content-string-interpolations

--- a/Just.sublime-syntax
+++ b/Just.sublime-syntax
@@ -53,7 +53,6 @@ contexts:
     - include: assignment
     - include: recipe-attribute
     - include: recipe-definition
-    - include: recipe-contents
 
   prototype:
     - include: comments
@@ -264,6 +263,7 @@ contexts:
   recipe-definition:
     - match: '(?=^@?{{valid_name}}[^:]*:[^=])' # Matches 'recipeName:' but not 'varName :='
       push:
+        - recipe-body
         - recipe-name
         - recipe-modifier
 
@@ -345,15 +345,22 @@ contexts:
     - include: just-expressions
     - include: else-pop
 
+  recipe-body:
+    # python script identified via shebang
+    - match: ^\s+(?=#!.*\bpython(?:\d(?:\.\d+)?)?\b)
+      pop: 1
+      embed: scope:source.python.embedded.just
+      escape: ^(?=\S)
+    # shell script is default
+    - match: ^
+      pop: 1
+      embed: scope:source.shell.embedded.just
+      escape: ^(?=\S)
+
 
 ###[ RECIPE CONTENTS ]#########################################################
 
-  recipe-contents:
-    - match: '(?=^\s+)'
-      comment: Recipe contents are always indented
-      push: recipe-content-line
-
-  recipe-content-line:
+  recipe-content-modifiers:
     - match: '^\s+((@)|(-)(@)|(-)|(@)(-))(?!-)'
       captures:
         2: storage.modifier.quiet.just
@@ -362,10 +369,6 @@ contexts:
         5: storage.modifier.ignore-error.just
         6: storage.modifier.quiet.just
         7: storage.modifier.ignore-error.just
-    - include: recipe-content-interpolations
-    - include: recipe-content-strings
-    - include: recipe-content-shebang
-    - include: eol-pop
 
   recipe-content-interpolations:
     - match: '\{\{\{\{'
@@ -381,44 +384,6 @@ contexts:
       pop: 1
     - include: just-expressions
 
-  # Sadly, almost an exact duplicate of the 'strings' context, but
-  # needed to include interpolations, which would have to be nested
-  # inside a push: in the other context.
-  recipe-content-strings:
-    - match: '`'
-      scope: punctuation.definition.string.begin.just
-      push:
-        - meta_scope: meta.string.just string.quoted.backtick.just
-        - meta_include_prototype: false
-        - match: \\.
-          scope: constant.character.escape.just
-        - match: '`'
-          scope: punctuation.definition.string.end.just
-          pop: 1
-        - include: recipe-content-string-interpolations
-    - match: '"'
-      scope: punctuation.definition.string.begin.just
-      push:
-        - meta_scope: meta.string.just string.quoted.double.just
-        - meta_include_prototype: false
-        - match: \\.
-          scope: constant.character.escape.just
-        - match: '"'
-          scope: punctuation.definition.string.end.just
-          pop: 1
-        - include: recipe-content-string-interpolations
-    - match: "'"
-      scope: punctuation.definition.string.begin.just
-      push:
-        - meta_scope: meta.string.just string.quoted.single.just
-        - meta_include_prototype: false
-        - match: \\.
-          scope: constant.character.escape.just
-        - match: "'"
-          scope: punctuation.definition.string.end.just
-          pop: 1
-        - include: recipe-content-string-interpolations
-
   recipe-content-string-interpolations:
     - match: '\{\{\{\{'
       comment: Escaped double brace. Do nothing
@@ -430,14 +395,6 @@ contexts:
     - clear_scopes: 1
     - meta_scope: meta.interpolation.just
     - include: recipe-content-interpolation-body
-
-  recipe-content-shebang:
-    - match: '^\s+#\!'
-      comment: The #! lines within a recipe.
-      push:
-        - meta_scope: comment.line.shebang.just
-        - match: $
-          pop: 1
 
 
 ###[ Set Expressions ]#########################################################

--- a/tests/syntax_test_just.recipe_declaration.just
+++ b/tests/syntax_test_just.recipe_declaration.just
@@ -25,7 +25,7 @@ b: a && d (_bar2 justfile())
 #^ keyword.operator.assignment.just
 #  ^ entity.name.function.just
 #    ^^ keyword.operator.logical.just
-#       ^ entity.name.function.just 
+#       ^ entity.name.function.just
 #         ^ punctuation.section.group.begin.just
 #          ^^^^^ entity.name.function.just
 #                ^^^^^^^^ meta.function-call.identifier.just support.function.builtin.just
@@ -104,11 +104,15 @@ script2 *ARGS:
 #        ^^^^ meta.function.parameters.just variable.parameter.just
 #            ^ keyword.operator.assignment.just
     {{ python }} script2.py {{ ARGS }}
+#   ^^^^^^^^^^^^ source.shell.embedded.just meta.function-call.identifier.shell meta.interpolation.just
+#               ^^^^^^^^^^^^^^^^^^^^^^ source.shell.embedded.just meta.function-call.arguments.shell
+#                           ^^^^^^^^^^ meta.interpolation.just
 
 script3:
     #!/usr/bin/python3
-#   ^^^^^^^^^^^^^^^^^^ comment.line.shebang.just
-    print("hello world")
+    # <- source.python.embedded.just comment.line.number-sign.python punctuation.definition.comment.python
+    #^^^^^^^^^^^^^^^^^^ source.python.embedded.just comment.line.number-sign.python
+    print("hello {{ ARGS }} world")
 
 
 #
@@ -116,15 +120,15 @@ script3:
 #
 _build version:
     @-echo 'Building {{justfile() + "string"}}…'
-#          ^^^^^^^^^^ meta.string.just string.quoted.single.just - meta.interpolation
-#                    ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.just meta.interpolation.just - string.quoted.single
-#                                             ^^ meta.string.just string.quoted.single.just - meta.interpolation
-#                      ^^^^^^^^ meta.function-call.identifier.just support.function.builtin.just
-#                              ^ meta.function-call.arguments.just punctuation.section.group.begin.just
-#                               ^ meta.function-call.arguments.just punctuation.section.group.end.just
-#                                 ^ keyword.operator.arithmetic.just
-#                                   ^^^^^^^^ string.quoted.double.just
-#                                           ^^ punctuation.section.interpolation.end.just
+    #      ^^^^^^^^^^ meta.string.shell string.quoted.single.shell - meta.interpolation
+    #                ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.shell meta.interpolation.just - string.quoted.single
+    #                                         ^^ meta.string.shell string.quoted.single.shell - meta.interpolation
+    #                  ^^^^^^^^ meta.function-call.identifier.just support.function.builtin.just
+    #                          ^ meta.function-call.arguments.just punctuation.section.group.begin.just
+    #                           ^ meta.function-call.arguments.just punctuation.section.group.end.just
+    #                             ^ keyword.operator.arithmetic.just
+    #                               ^^^^^^^^ string.quoted.double.just
+    #                                       ^^ punctuation.section.interpolation.end.just
     cd {{version}} && make
 
 # Argument to dependency
@@ -147,24 +151,29 @@ r2 +$f:
 #  ^^ meta.function.parameters.just
 #  ^ keyword.operator.variadic.just
 #   ^ keyword.operator.exported.just
+    echo "v"
 
 r1 $*f:
 #  ^^ meta.function.parameters.just invalid.illegal.just
+    echo "v"
 
 r2 +$+f:
 #  ^^^ meta.function.parameters.just
 #  ^ keyword.operator.variadic.just
 #   ^^ invalid.illegal.just
+    echo "v"
 
 r3 +$*f:
 #  ^^^ meta.function.parameters.just
 #  ^ keyword.operator.variadic.just
 #   ^^ invalid.illegal.just
+    echo "v"
 
 r4 $$f:
 #  ^^ meta.function.parameters.just
 #  ^ invalid.illegal.just
 #   ^ keyword.operator.exported.just
+    echo "v"
 
 r5 +$+$ f:
 #  ^^^^ meta.function.parameters.just
@@ -177,17 +186,6 @@ r6 **$f:
 #  ^ keyword.operator.variadic.just
 #   ^ invalid.illegal.just
 #    ^ keyword.operator.exported.just
-
-r7 $:
-#  ^ meta.function.parameters.just invalid.illegal.just
-
-
-r8 +:
-#  ^ meta.function.parameters.just invalid.illegal.just
-
-r9 +$:
-#  ^^ meta.function.parameters.just
-#   ^ invalid.illegal.just
 
 
 #

--- a/tests/syntax_test_just.recipe_declaration.just
+++ b/tests/syntax_test_just.recipe_declaration.just
@@ -151,29 +151,24 @@ r2 +$f:
 #  ^^ meta.function.parameters.just
 #  ^ keyword.operator.variadic.just
 #   ^ keyword.operator.exported.just
-    echo "v"
 
 r1 $*f:
 #  ^^ meta.function.parameters.just invalid.illegal.just
-    echo "v"
 
 r2 +$+f:
 #  ^^^ meta.function.parameters.just
 #  ^ keyword.operator.variadic.just
 #   ^^ invalid.illegal.just
-    echo "v"
 
 r3 +$*f:
 #  ^^^ meta.function.parameters.just
 #  ^ keyword.operator.variadic.just
 #   ^^ invalid.illegal.just
-    echo "v"
 
 r4 $$f:
 #  ^^ meta.function.parameters.just
 #  ^ invalid.illegal.just
 #   ^ keyword.operator.exported.just
-    echo "v"
 
 r5 +$+$ f:
 #  ^^^^ meta.function.parameters.just
@@ -186,6 +181,17 @@ r6 **$f:
 #  ^ keyword.operator.variadic.just
 #   ^ invalid.illegal.just
 #    ^ keyword.operator.exported.just
+
+r7 $:
+#  ^ meta.function.parameters.just invalid.illegal.just
+
+
+r8 +:
+#  ^ meta.function.parameters.just invalid.illegal.just
+
+r9 +$:
+#  ^^ meta.function.parameters.just
+#   ^ invalid.illegal.just
 
 
 #


### PR DESCRIPTION
Here's a proposal to support Python and ShellScript syntax in receipt content.

It extends ST's Python and Bash syntax to inject Just's interpolations and embeds extended syntaxes into Just itself.

Please note, neither Python nor Bash currently support clearing string scope in string interpolations. I've prepared a `string-prototype` context to enable 3rd-party syntaxes to do so, but that still needs to be pushed to ST's Packages repository.

In the meanwhile some tests may fail due to `string-prototype` being ignored.
