### PR TITLE
Upgrade embedded Python to syntax v2

### DIFF
--- a/Syntax/Embeddings/Python (for Just).sublime-syntax
+++ b/Syntax/Embeddings/Python (for Just).sublime-syntax
@@ -1,9 +1,8 @@
 %YAML 1.2
 ---
-name: Python (for Just) v1
+name: Python (for Just)
 scope: source.python.embedded.just
-# Version needs to match the one that ships with Sublime. v1 as of Jan 2023.
-version: 1
+version: 2
 hidden: true
 
 extends: Packages/Python/Python.sublime-syntax

--- a/Syntax/tests/syntax_test_just.recipe_embeddings.just
+++ b/Syntax/tests/syntax_test_just.recipe_embeddings.just
@@ -6,8 +6,9 @@ python3 *ARGS:
   print("hello {{ ARGS }} world")
  #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.python.embedded.just
  #     ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.python
- #      ^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.python string.quoted.double.python
- #             ^^^^^^^^^^ meta.interpolation.just
+ #      ^^^^^^^ meta.string.python string.quoted.double.python - meta.interpolation
+ #             ^^^^^^^^^^ meta.string.python meta.interpolation.just - string
+ #                       ^^^^^^^ meta.string.python string.quoted.double.python - meta.interpolation
 
 bash *$ARGS:
   #!/bin/sh


### PR DESCRIPTION
This PR fixes a compatibility error with ST 4148, which ships with a sublime-syntax v2 Python.

> **Warning**
>
> This fix breaks compatibility with older ST builds. Thus a new release branch at packagecontrol.io is required.

To create a new release branch, I'd recommend to prefix your tags with the least required ST build number.

Example:

- 4075-1.1.2 (with v1 python)
- 4148-1.1.2 (with v2 python)

A corresponding change in package_control_channel would be required.