### PR TITLE
Variable pattern formats

### DIFF
--- a/Syntax/Just.sublime-syntax
+++ b/Syntax/Just.sublime-syntax
@@ -18,37 +18,25 @@ file_extensions:
 
 variables:
   valid_name: '[a-zA-Z_][a-zA-Z0-9_-]*'
-  built_in_functions: |
-    (?x)(?:  # ignore whitespace in this regex
-
-      absolute_path | arch | capitalize | clean | env_var_or_default | env_var |
-      error | extension | file_name | file_stem | invocation_directory_native |
-      invocation_directory |
-      join | just_executable | justfile_directory | justfile | kebabcase |
-      lowercamelcase | lowercase | os_family | os | parent_directory |
-      path_exists | quote | replace_regex | replace | sha256_file | sha256 |
-      shoutykebabcase | shoutysnakecase | snakecase | titlecase |
-      trim_end_matches | trim_end_match | trim_end | trim_start_matches |
-      trim_start_match | trim_start | trim | uppercase | uppercamelcase |
-      uuid | without_extension
-    )
-  boolean_settings: |
-    (?x)(?:
-      allow-duplicate-recipes | dotenv-load | export | fallback | ignore-comments |
-      positional-arguments | windows-powershell
-    )
-  string_settings: |
-    (?x)(?:
-      tempdir
-    )
-  shell_settings: |
-    (?x)(?:
-      shell | windows-shell
-    )
-  recipe_attributes: |
-    (?x)
-      linux | macos | no-cd | no-exit-message | private | unix | windows
-
+  built_in_functions: |-
+    (?x: absolute_path | arch | capitalize | clean | env_var_or_default | env_var
+    | error | extension | file_name | file_stem | invocation_directory_native
+    | invocation_directory | join | just_executable | justfile_directory | justfile
+    | kebabcase | lowercamelcase | lowercase | os_family | os | parent_directory
+    | path_exists | quote | replace_regex | replace | sha256_file | sha256
+    | shoutykebabcase | shoutysnakecase | snakecase | titlecase
+    | trim_end_matches | trim_end_match | trim_end | trim_start_matches
+    | trim_start_match | trim_start | trim | uppercase | uppercamelcase
+    | uuid | without_extension )
+  boolean_settings: |-
+    (?x: allow-duplicate-recipes | dotenv-load | export | fallback | ignore-comments
+    | positional-arguments | windows-powershell )
+  string_settings: |-
+    (?x: tempdir )
+  shell_settings: |-
+    (?x: shell | windows-shell )
+  recipe_attributes: |-
+    (?x: linux | macos | no-cd | no-exit-message | private | unix | windows )
 
 ###############################################################################
 # MAIN CONTEXT


### PR DESCRIPTION
Turn variable patterns into groups to avoid global flag `(?x)` effecting in unintentional ways the whole pattern the variables are used in.

see: https://github.com/nk9/just_sublime/commit/55bcccda41b3da2225ea5e15854535f8a2114fb5#r110738904