### PR TITLE
[#19] Fix for the stack not being properly reset after a set line.

### DIFF
--- a/Syntax/Just.sublime-syntax
+++ b/Syntax/Just.sublime-syntax
@@ -503,61 +503,71 @@ contexts:
 # Ex: "set shell := ['zsh', '-cu']", "set dotenv-load", "set export := false"
 
   settings:
-    - match: ^set(?=\s+)
+    - match: ^set(?=\s)
       scope: storage.modifier.definition.just
-      push:
-        - settings-invalid
-        - settings-shell
-        - settings-boolean
-        - settings-string
+      push: settings-name
 
-  settings-invalid:
-    - match: \b({{valid_name}})\b\s*:=
-      captures:
-        1: invalid.illegal.just
+  settings-name:
+    - include: settings-shell-name
+    - include: settings-boolean-name
+    - include: settings-string-name
+    - include: settings-invalid-name
     - include: else-pop
 
-  settings-shell:
-    - match: \b{{shell_settings}}\b
+  settings-boolean-name:
+    - match: '{{boolean_settings}}\b'
       scope: entity.name.definition.just
       set:
-        - string-array
+        - settings-boolean-value
         - assignment-operator
-    - include: else-pop
 
-  settings-boolean:
-    - match: \b{{boolean_settings}}\b
-      scope: entity.name.definition.just
-      set:
-        - constant-boolean
-        - assignment-operator
-    - include: else-pop
-
-  settings-string:
-    - match: \b{{string_settings}}\b
-      scope: entity.name.definition.just
-      push:
-        - assignment-operator
-    - include: strings
-    - include: else-pop
-
-  constant-boolean:
-    - match: \b(true|false)\b
-      captures:
-        1: constant.language.boolean.just
+  settings-boolean-value:
+    - match: (?:true|false)\b
+      scope: constant.language.boolean.just
       pop: 1
     - include: else-pop
+    - include: eol-pop
 
-  string-array:
-    - meta_scope: meta.sequence.list.just
+  settings-invalid-name:
+    - match: ({{valid_name}})\b\s*:=
+      captures:
+        1: invalid.illegal.just
+      push: eol-pop
+
+  settings-shell-name:
+    - match: '{{shell_settings}}\b'
+      scope: entity.name.definition.just
+      set:
+        - settings-shell-value
+        - assignment-operator
+
+  settings-shell-value:
     - match: \[
       scope: punctuation.section.brackets.start.just
-    - match: ','
-      scope: punctuation.separator.parameters.just
+      set: string-array-body
+    - include: else-pop
+    - include: eol-pop
+
+  string-array-body:
+    - meta_scope: meta.sequence.list.just
     - match: \]
       scope: punctuation.section.brackets.end.just
       pop: 1
+    - match: ','
+      scope: punctuation.separator.parameters.just
     - include: strings
+    - include: eol-pop #??
+
+  settings-string-name:
+    - match: '{{string_settings}}\b'
+      scope: entity.name.definition.just
+      set:
+        - settings-string-value
+        - assignment-operator
+
+  settings-string-value:
+    - include: strings
+    - include: eol-pop
 
 # ###[ General Types ]##########################################################
 

--- a/Syntax/Just.sublime-syntax
+++ b/Syntax/Just.sublime-syntax
@@ -520,7 +520,6 @@ contexts:
   settings-shell:
     - match: \b{{shell_settings}}\b
       scope: entity.name.definition.just
-      pop: 1 # Clear the settings-invalid scope from the stack
       set:
         - string-array
         - assignment-operator
@@ -559,7 +558,6 @@ contexts:
       scope: punctuation.section.brackets.end.just
       pop: 1
     - include: strings
-    - include: else-pop
 
 # ###[ General Types ]##########################################################
 

--- a/Syntax/Just.sublime-syntax
+++ b/Syntax/Just.sublime-syntax
@@ -507,8 +507,8 @@ contexts:
       scope: storage.modifier.definition.just
       push:
         - settings-invalid
-        - settings-boolean
         - settings-shell
+        - settings-boolean
         - settings-string
 
   settings-invalid:
@@ -517,10 +517,19 @@ contexts:
         1: invalid.illegal.just
     - include: else-pop
 
+  settings-shell:
+    - match: \b{{shell_settings}}\b
+      scope: entity.name.definition.just
+      pop: 1 # Clear the settings-invalid scope from the stack
+      set:
+        - string-array
+        - assignment-operator
+    - include: else-pop
+
   settings-boolean:
     - match: \b{{boolean_settings}}\b
       scope: entity.name.definition.just
-      push:
+      set:
         - constant-boolean
         - assignment-operator
     - include: else-pop
@@ -533,14 +542,6 @@ contexts:
     - include: strings
     - include: else-pop
 
-  settings-shell:
-    - match: \b{{shell_settings}}\b
-      scope: entity.name.definition.just
-      push:
-        - string-array
-        - assignment-operator
-    - include: else-pop
-
   constant-boolean:
     - match: \b(true|false)\b
       captures:
@@ -549,6 +550,7 @@ contexts:
     - include: else-pop
 
   string-array:
+    - meta_scope: meta.sequence.list.just
     - match: \[
       scope: punctuation.section.brackets.start.just
     - match: ','
@@ -557,6 +559,7 @@ contexts:
       scope: punctuation.section.brackets.end.just
       pop: 1
     - include: strings
+    - include: else-pop
 
 # ###[ General Types ]##########################################################
 

--- a/Syntax/Just.sublime-syntax
+++ b/Syntax/Just.sublime-syntax
@@ -508,8 +508,8 @@ contexts:
       push: settings-name
 
   settings-name:
-    - include: settings-shell-name
     - include: settings-boolean-name
+    - include: settings-shell-name
     - include: settings-string-name
     - include: settings-invalid-name
     - include: else-pop

--- a/Syntax/tests/syntax_test_just.settings.just
+++ b/Syntax/tests/syntax_test_just.settings.just
@@ -51,6 +51,7 @@ set shell := ["sh", "-c"]
 #   ^^^^^ entity.name.definition.just
 #         ^^ keyword.operator.assignment.just
 #            ^ punctuation.section.brackets.start.just
+#            ^^^^^^^^^^^^ meta.sequence.list.just
 #             ^^^^ string.quoted.double.just
 #                 ^ punctuation.separator.parameters.just
 #                   ^^^^ string.quoted.double.just
@@ -103,3 +104,30 @@ set export := trued
 
 set dotenv-load := falsey
 #                  ^^^^^^ - constant.language.boolean.just
+
+
+
+# [#19] First variable assignment following a set marked as invalid
+set positional-arguments
+export ONE := "1"
+#<- keyword.declaration.variable.just
+#^^^^^ keyword.declaration.variable.just
+#      ^^^ variable.other.just
+#          ^^ keyword.operator.assignment.just
+#             ^^^ string.quoted.double.just 
+
+set export := true
+export TRY := "1"
+#<- keyword.declaration.variable.just
+#^^^^^ keyword.declaration.variable.just
+#      ^^^ variable.other.just
+#          ^^ keyword.operator.assignment.just
+#             ^^^ string.quoted.double.just 
+
+set shell := ["sh", "-c"]
+export TWO := "2"
+#<- keyword.declaration.variable.just
+#^^^^^ keyword.declaration.variable.just
+#      ^^^ variable.other.just
+#          ^^ keyword.operator.assignment.just
+#             ^^^ string.quoted.double.just 

--- a/Syntax/tests/syntax_test_just.settings.just
+++ b/Syntax/tests/syntax_test_just.settings.just
@@ -114,7 +114,7 @@ export ONE := "1"
 #^^^^^ keyword.declaration.variable.just
 #      ^^^ variable.other.just
 #          ^^ keyword.operator.assignment.just
-#             ^^^ string.quoted.double.just 
+#             ^^^ string.quoted.double.just
 
 set export := true
 export TRY := "1"
@@ -122,7 +122,7 @@ export TRY := "1"
 #^^^^^ keyword.declaration.variable.just
 #      ^^^ variable.other.just
 #          ^^ keyword.operator.assignment.just
-#             ^^^ string.quoted.double.just 
+#             ^^^ string.quoted.double.just
 
 set shell := ["sh", "-c"]
 export TWO := "2"
@@ -130,4 +130,13 @@ export TWO := "2"
 #^^^^^ keyword.declaration.variable.just
 #      ^^^ variable.other.just
 #          ^^ keyword.operator.assignment.just
-#             ^^^ string.quoted.double.just 
+#             ^^^ string.quoted.double.just
+
+set tempdir := ""
+export := true
+# <- - entity
+
+set tempdir := ""
+export := true
+shell := ["sh", "-c"]
+# <- - entity


### PR DESCRIPTION
~~This change seems to address #19, and I understand why it does. But I am a little confused why `settings-shell` needs both a `set` and a `pop` directive, but `settings-boolean` is fixed by just using `set`.~~

**Update:** It looks like it's not actually needed. I've removed the two pops and the tests all still pass.

@deathaxe, I'd (still) be grateful if you could confirm for me that I've done this correctly.