### PR TITLE
Preserve block indentation when commenting

### DIFF
--- a/Syntax/Comments.tmPreferences
+++ b/Syntax/Comments.tmPreferences
@@ -13,12 +13,6 @@
 				<key>value</key>
 				<string># </string>
 			</dict>
-			<dict>
-				<key>name</key>
-				<string>TM_COMMENT_DISABLE_INDENT</string>
-				<key>value</key>
-				<string>yes</string>
-			</dict>
 		</array>
 	</dict>
 </dict>


### PR DESCRIPTION
This change allows the comment keyboard shortcut to be used to comment out lines of a recipe without requiring a manual fixup afterwards. Without this change, the pound sign `#` gets introduced at the start of the line, which confuses the Just parser if there are additional recipe lines after the commented-out line.